### PR TITLE
tap after hittable

### DIFF
--- a/TABTestKit/Classes/Protocols/Tappable.swift
+++ b/TABTestKit/Classes/Protocols/Tappable.swift
@@ -22,36 +22,36 @@ public extension Element where Self: Tappable {
 
 	func tap() {
     #if swift(>=5.5)
-		  waitFor(.exists)
+		  waitFor(.hittable)
     #else
-      await(.exists)
+      await(.hittable)
     #endif
 		underlyingXCUIElement.tap()
 	}
 
 	func doubleTap() {
     #if swift(>=5.5)
-      waitFor(.exists)
+      waitFor(.hittable)
     #else
-      await(.exists)
+      await(.hittable)
     #endif
 		underlyingXCUIElement.doubleTap()
 	}
 
 	func twoFingerTap() {
     #if swift(>=5.5)
-      waitFor(.exists)
+      waitFor(.hittable)
     #else
-      await(.exists)
+      await(.hittable)
     #endif
 		underlyingXCUIElement.twoFingerTap()
 	}
 
 	func longPress(duration: TimeInterval) {
     #if swift(>=5.5)
-      waitFor(.exists)
+      waitFor(.hittable)
     #else
-      await(.exists)
+      await(.hittable)
     #endif
 		underlyingXCUIElement.press(forDuration: duration)
 	}


### PR DESCRIPTION
#### What's in this PR?

The main implementation of tap() awaits for an element to exist, but that doesn't mean it's ready to be tapped. Although it exists in the view hierarchy, it may not be visible or have interactions enabled. 
---

#### Proposed changes

Replace .exists with .hittable, ensuring that the item is able to receive the gesture. 
